### PR TITLE
feat: add method to retrieve in cents

### DIFF
--- a/src/Casts/NumberFromCents.php
+++ b/src/Casts/NumberFromCents.php
@@ -23,6 +23,6 @@ class NumberFromCents implements CastsAttributes
             throw ValueIsNotANumberException::fromCents();
         }
 
-        return $value->mul(100)->getValue()->toInt();
+        return $value->inCents();
     }
 }

--- a/src/Number.php
+++ b/src/Number.php
@@ -185,6 +185,11 @@ class Number
         return $this->value->toFloat();
     }
 
+    public function inCents(): int
+    {
+        return (int) str_replace('.', '', $this->toString());
+    }
+
     public function __toString(): string
     {
         return $this->toString();

--- a/src/Number.php
+++ b/src/Number.php
@@ -187,7 +187,7 @@ class Number
 
     public function inCents(): int
     {
-        return (int) str_replace('.', '', $this->toString());
+        return $this->mul(100)->getValue()->toInt();
     }
 
     public function __toString(): string

--- a/tests/Unit/NumberTest.php
+++ b/tests/Unit/NumberTest.php
@@ -250,6 +250,8 @@ it('can check if equal to', function (int|string|float $number, int|string|float
     '10.01 is 1001' => [1001, 1001],
     '0 is 0' => [0, 0],
     '-101.10 is -10110' => [-101.10, -101.10],
+    '101.001 as string is 101.001' => ['101.001', 101.001],
+    '-101.001 as string is -101.001' => ['-101.001', -101.001],
 ]);
 
 it('can get Number in cents', function (int|string|float $number, int $result) {
@@ -261,4 +263,6 @@ it('can get Number in cents', function (int|string|float $number, int $result) {
     '101.10 as string is 10110' => ['101.10', 10110],
     '1111111101.99 as string is 111111110199' => ['1111111101.99', 111111110199],
     '1.10 as string is 110' => ['1.10', 110],
+    '-1.10 is -110' => [-1.10, -110],
+    '-1111111101.99 is -111111110199' => [-1111111101.99, -111111110199],
 ]);

--- a/tests/Unit/NumberTest.php
+++ b/tests/Unit/NumberTest.php
@@ -242,3 +242,23 @@ it('can check whether number is positive or zero', function (int $number, bool $
     '-1 is not positive or zero' => [-1, false],
     '-10000 is not positive or zero' => [-10000, false],
 ]);
+
+it('can check if equal to', function (int|string|float $number, int|string|float $comparison) {
+    expect(Number::of($number)->isEqualTo(Number::of($comparison)))->toBe(true);
+})->with([
+    '1 is 1' => [1, 1],
+    '10.01 is 1001' => [1001, 1001],
+    '0 is 0' => [0, 0],
+    '-101.10 is -10110' => [-101.10, -101.10],
+]);
+
+it('can get Number in cents', function (int|string|float $number, int $result) {
+    expect(Number::of($number)->inCents())->toBe($result);
+})->with([
+    '1.00 as string is 1' => ['1.00', 100],
+    '10.01 is 1001' => [10.01, 1001],
+    '0 is 0' => [0.00, 0],
+    '101.10 as string is 10110' => ['101.10', 10110],
+    '1111111101.99 as string is 111111110199' => ['1111111101.99', 111111110199],
+    '1.10 as string is 110' => ['1.10', 110],
+]);


### PR DESCRIPTION
This is based off input from Vahid, however I'm not sure this seems fully correct. But I think this is more of an issue with floats in general as an input type 😐

For example:
```php
Number::of('101.10')->toCents(); // 10110 ✅
Number::of(101.10)->toCents(); // 1011 ❌
```

It seems that the trailing zero is stripped from the input, which... isn't what we want. 😬 I'm not sure if this is even an issue, as our values are stored as `decimal` in the DB, which is retrieved as a string. So in theory, this should always do the first one. Perhaps I just remove `float` support from all methods? 🤔 So it's either `int|string|Number|BigDecimal`