### PR TITLE
chore(deps): fix types on scalars

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": "^8.0",
         "brick/math": "^0.9.3",
-        "nuwave/lighthouse": "^5.57"
+        "nuwave/lighthouse": "^5.61",
+        "webonyx/graphql-php": "^14.11.7"
     },
     "require-dev": {
         "nunomaduro/collision": "^5.10 || ^6.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Parameter \\#2 \\$nodes of class GraphQL\\\\Error\\\\Error constructor expects GraphQL\\\\Language\\\\AST\\\\Node\\|\\(iterable\\<GraphQL\\\\Language\\\\AST\\\\Node\\>&Traversable\\)\\|null, array\\<int, GraphQL\\\\Language\\\\AST\\\\BooleanValueNode\\|GraphQL\\\\Language\\\\AST\\\\NullValueNode\\|GraphQL\\\\Language\\\\AST\\\\StringValueNode\\> given\\.$#"
-			count: 1
-			path: src/GraphQL/Scalars/PercentageType.php
-
-		-
-			message: "#^Parameter \\#2 \\$nodes of class GraphQL\\\\Error\\\\Error constructor expects GraphQL\\\\Language\\\\AST\\\\Node\\|\\(iterable\\<GraphQL\\\\Language\\\\AST\\\\Node\\>&Traversable\\)\\|null, array\\<int, GraphQL\\\\Language\\\\AST\\\\BooleanValueNode\\|GraphQL\\\\Language\\\\AST\\\\NullValueNode\\|GraphQL\\\\Language\\\\AST\\\\StringValueNode\\> given\\.$#"
-			count: 1
-			path: src/GraphQL/Scalars/StrictPercentageType.php

--- a/src/GraphQL/Scalars/PercentageType.php
+++ b/src/GraphQL/Scalars/PercentageType.php
@@ -15,7 +15,7 @@ use Worksome\Number\Percentage;
 
 final class PercentageType extends ScalarType
 {
-    public $description = <<<TXT
+    public string|null $description = <<<TXT
         The `Percentage` scalar type represents a percentage.
         TXT;
 

--- a/src/GraphQL/Scalars/StrictPercentageType.php
+++ b/src/GraphQL/Scalars/StrictPercentageType.php
@@ -15,7 +15,7 @@ use Worksome\Number\StrictPercentage;
 
 final class StrictPercentageType extends ScalarType
 {
-    public $description = <<<TXT
+    public string|null $description = <<<TXT
         The `StrictPercentage` scalar type represents a percentage that cannot be less than 0% or greater than 100%.
         TXT;
 

--- a/tests/__snapshots__/PercentageTypeTest__it_can_generate_schema_for_GraphQL_Percentage_scalar__1.txt
+++ b/tests/__snapshots__/PercentageTypeTest__it_can_generate_schema_for_GraphQL_Percentage_scalar__1.txt
@@ -1,2 +1,2 @@
-"""The `Percentage` scalar type represents a percentage."""
+"The `Percentage` scalar type represents a percentage."
 scalar Percentage


### PR DESCRIPTION
It looks like `webonyx/graphql-php` is breaking with the package on `^14.11.7` because of [this change](https://github.com/webonyx/graphql-php/commit/d8ccdfe7fd637a6865b936b2b4022eaa9dfae735#diff-c8e66829316fb28b82a72b521c4e10919d71b790439b45166043ce80729b2908) where the types are more strictly enforced. 😬 / 🥳

I've updated the types to be strictly typed here too.