### PR TITLE
feat: support skipping `null` values in `sum()`

### DIFF
--- a/src/Number.php
+++ b/src/Number.php
@@ -173,12 +173,16 @@ class Number
         return $this->value->isPositiveOrZero();
     }
 
-    /** @param iterable<static> $values */
+    /** @param iterable<static|null> $values */
     public static function sum(iterable $values): static
     {
         $sum = static::of('0');
 
         foreach ($values as $value) {
+            if ($value === null) {
+                continue;
+            }
+
             $sum = $sum->add($value);
         }
 

--- a/tests/Unit/NumberTest.php
+++ b/tests/Unit/NumberTest.php
@@ -293,3 +293,13 @@ it('can get sum of numbers', function () {
 
     expect($sum)->toEqual(Number::of('3'));
 });
+
+it('skips null values when using sum', function () {
+    $sum = Number::sum([
+        Number::of('1'),
+        null,
+        null,
+    ]);
+
+    expect($sum)->toEqual(Number::of('1'));
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Sum operations now properly handle null values in input datasets by automatically ignoring them, preventing errors and ensuring calculation results remain accurate and reliable

**Tests**
- Added comprehensive unit tests to verify that sum calculations correctly ignore null values in input arrays, ensuring accuracy and reliability when processing datasets containing null entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->